### PR TITLE
Fixed Windows 10 right-click crashes

### DIFF
--- a/Explorer++/Helper/ContextMenuManager.cpp
+++ b/Explorer++/Helper/ContextMenuManager.cpp
@@ -233,9 +233,19 @@ void CContextMenuManager::AddMenuEntries(HMENU hMenu,
 	{
 		if(itr->pContextMenuActual != NULL)
 		{
-			HRESULT hr = itr->pContextMenuActual->QueryContextMenu(
-				hMenu,iStartPos,iMinID + iOffset,iMaxID,
-				CMF_NORMAL|CMF_EXPLORE);
+			/* Windows 10 right-click crashes in QueryContextMenu call
+			in OneDrive's FileSyncShell[64].dll - handle the exception here. */
+			HRESULT hr = MAKE_HRESULT(SEVERITY_ERROR,0,0);
+			try
+			{
+				hr = itr->pContextMenuActual->QueryContextMenu(
+					hMenu,iStartPos,iMinID + iOffset,iMaxID,
+					CMF_NORMAL|CMF_EXPLORE);
+			}
+			catch (...)
+			{
+				continue;
+			}
 
 			if(HRESULT_SEVERITY(hr) == SEVERITY_SUCCESS)
 			{

--- a/Explorer++/Helper/Helper.vcxproj
+++ b/Explorer++/Helper/Helper.vcxproj
@@ -97,6 +97,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(BOOST);$(STLSOFT)\include;$(PANTHEIOS)\include</AdditionalIncludeDirectories>
+	  <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -123,6 +124,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CallingConvention>Cdecl</CallingConvention>
       <AdditionalIncludeDirectories>$(BOOST);$(STLSOFT)\include;$(PANTHEIOS)\include</AdditionalIncludeDirectories>
+	  <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -145,6 +147,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(BOOST);$(STLSOFT)\include;$(PANTHEIOS)\include</AdditionalIncludeDirectories>
+	  <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>version.lib;iphlpapi.lib;userenv.lib;wmvcore.lib;rpcrt4.lib;%(AdditionalDependencies);windowscodecs.lib;shlwapi.lib;gdiplus.lib;psapi.lib</AdditionalDependencies>
@@ -164,6 +167,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(BOOST);$(STLSOFT)\include;$(PANTHEIOS)\include</AdditionalIncludeDirectories>
+	  <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>version.lib;iphlpapi.lib;userenv.lib;wmvcore.lib;rpcrt4.lib;%(AdditionalDependencies);</AdditionalDependencies>


### PR DESCRIPTION
Fixes #35 - the crash occurs in the QueryContextMenu call in OneDrive's FileSyncShell[64].dll - this fix is based on code proposed by @GeorgeHahn in issue #35.
